### PR TITLE
Fix Uri with special character

### DIFF
--- a/src/SerConAai.csproj
+++ b/src/SerConAai.csproj
@@ -21,7 +21,7 @@
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="SerApi" Version="3.1.1" />
-        <PackageReference Include="SerDistribute" Version="2.0.4" />
+        <PackageReference Include="SerDistribute" Version="2.0.5" />
         <PackageReference Include="Q2gHelperPem" Version="1.0.6" />
         <PackageReference Include="Q2gHelperQrs" Version="1.1.0" />
       </ItemGroup>

--- a/src/SerEvaluator.cs
+++ b/src/SerEvaluator.cs
@@ -522,10 +522,11 @@ namespace Ser.ConAai
             foreach (var task in config.Tasks)
             {
                 var report = task.Reports.FirstOrDefault() ?? null;
-                var templateUri = new Uri(report.Template.Input);
+                var result = UriUtils.NormalizeUri(report.Template.Input);
+                var templateUri = result.Item1;
                 if (templateUri.Scheme.ToLowerInvariant() == "content")
                 {
-                    var contentFiles = GetLibraryContent(onDemandConfig.Connection.ServerUri, parameter.AppId, cookie, templateUri.Host);
+                    var contentFiles = GetLibraryContent(onDemandConfig.Connection.ServerUri, parameter.AppId, cookie, result.Item2);
                     logger.Debug($"File count in content library: {contentFiles?.Count}");
                     var filterFile = contentFiles.FirstOrDefault(c => c.EndsWith(templateUri.AbsolutePath));
                     if (filterFile != null)
@@ -539,7 +540,7 @@ namespace Ser.ConAai
                 else if (templateUri.Scheme.ToLowerInvariant() == "lib")
                 {
                     var connections = GetConnections(onDemandConfig.Connection.ServerUri, parameter.AppId, cookie);
-                    dynamic libResult = connections?.FirstOrDefault(n => n["qName"]?.ToString()?.ToLowerInvariant() == templateUri.Host) ?? null;
+                    dynamic libResult = connections?.FirstOrDefault(n => n["qName"]?.ToString()?.ToLowerInvariant() == result.Item2) ?? null;
                     if (libResult != null)
                     {
                         var libPath = libResult.qConnectionString.ToString();

--- a/src/SerEvaluator.cs
+++ b/src/SerEvaluator.cs
@@ -263,6 +263,7 @@ namespace Ser.ConAai
                         }
                         else
                         {
+                            activeTask.Status = 0;
                             FinishTask(workDir, userParameter.CleanupTimeout, activeTask);
                         }
 


### PR DESCRIPTION
Uri (lib:// or content://) tested with:
- lib://$cont-_(my)'rice#{ohne}%&§!ß+~[ohne]' (nb-fc-208000_mberthold)
- content://$cont-_(my)'rice#{ohne}%&§!ß+~[ohne]/ExecutiveDashboard.xlsx